### PR TITLE
Fix dependency compatibility and the memory blowups that cap the demo to short sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,25 @@
 ```bash
 conda create --name pe3r
 conda activate pe3r
-git clone 
-pip install requirements.txt
+git clone https://github.com/hujiecpp/PE3R.git
+cd PE3R
+pip install -r requirements.txt
+```
+#### Checkpoints
+MASt3R, SAM 2, SAM and SigLIP are pulled from the Hugging Face Hub on first run.
+The two remaining weights are published under the `checkpoints`
+[release](https://github.com/hujiecpp/PE3R/releases/tag/checkpoints) and have to
+be downloaded manually:
+```bash
+mkdir -p checkpoints
+curl -L -o checkpoints/ObjectAwareModel.pt \
+  https://github.com/hujiecpp/PE3R/releases/download/checkpoints/ObjectAwareModel.pt
+curl -L -o checkpoints/Prompt_guided_Mask_Decoder.pt \
+  https://github.com/hujiecpp/PE3R/releases/download/checkpoints/Prompt_guided_Mask_Decoder.pt
 ```
 #### Usage
+Run from the repository root — the checkpoint paths are relative to the working
+directory.
 ```bash
 python pe3r_demo.py
 ```

--- a/modules/croco/models/pos_embed.py
+++ b/modules/croco/models/pos_embed.py
@@ -104,7 +104,7 @@ def interpolate_pos_embed(model, checkpoint_model):
 #----------------------------------------------------------
 
 try:
-    from models.curope import cuRoPE2D
+    from curope import cuRoPE2D
     RoPE2D = cuRoPE2D
 except ImportError:
     print('Warning, cannot find cuda-compiled version of RoPE2D, using a slow pytorch version instead')

--- a/modules/dust3r/cloud_opt/base_opt.py
+++ b/modules/dust3r/cloud_opt/base_opt.py
@@ -556,12 +556,12 @@ def global_alignment_iter(net, cur_iter, niter, lr_base, lr_min, optimizer, sche
     loss = net(cur_iter)
     if loss == 0:
         optimizer.step()
-        return float(loss), lr 
+        return 0, lr
 
     loss.backward()
     optimizer.step()
 
-    return float(loss), lr
+    return loss.item(), lr
 
 
 @torch.no_grad()

--- a/modules/dust3r/cloud_opt/base_opt.py
+++ b/modules/dust3r/cloud_opt/base_opt.py
@@ -127,56 +127,37 @@ class BasePCOptimizer (nn.Module):
             self.fix_imgs = rgb(ori_imgs)
             self.smoothed_imgs = rgb(smoothed_imgs)
         
-        self.cogs = [torch.zeros((h, w, 1024), device="cuda") for h, w in self.imshapes]
-        semantic_feats = semantic_feats.to("cuda")
-        self.segmaps = [-torch.ones((h, w), device="cuda") for h, w in self.imshapes]
-        self.rev_segmaps = [-torch.ones((h, w), device="cuda") for h, w in self.imshapes]
+        # A per-pixel copy of the semantic features would be h*w*1024 floats per image
+        # (0.56 GB at 288x512), and it is just semantic_feats gathered by the segmap.
+        # Keep the segmap and the feature table and gather on demand in render_image.
+        self.semantic_feats = semantic_feats.to("cuda")
+        self.segmaps = [-torch.ones((h, w), dtype=torch.long, device="cuda") for h, w in self.imshapes]
+        self.rev_segmaps = [-torch.ones((h, w), dtype=torch.long, device="cuda") for h, w in self.imshapes]
         # self.conf_1 = [torch.zeros((h, w), device="cuda") for h, w in self.imshapes]
         # self.conf_2 = [torch.zeros((h, w), device="cuda") for h, w in self.imshapes]
-        for v in range(len(self.edges)):
-            idx = view1['idx'][v]
-
-            h, w = self.cogs[idx].shape[0], self.cogs[idx].shape[1]
+        for idx in set(view1['idx']) | set(view2['idx']):
+            h, w = self.imshapes[idx]
             cog_seg_map = cog_seg_maps[idx]
             cog_seg_map = torch.from_numpy(cv2.resize(cog_seg_map, [w, h], interpolation=cv2.INTER_NEAREST))
             rev_seg_map = rev_cog_seg_maps[idx]
             rev_seg_map = torch.from_numpy(cv2.resize(rev_seg_map, [w, h], interpolation=cv2.INTER_NEAREST))
 
-            y, x = torch.meshgrid(torch.arange(0, h), torch.arange(0, w))
-            x = x.reshape(-1, 1)
-            y = y.reshape(-1, 1)
-            seg = cog_seg_map[y, x].squeeze(-1).long()
-
-            self.cogs[idx] = semantic_feats[seg].reshape(h, w, -1)
-            self.segmaps[idx] = cog_seg_map.cuda()
-            self.rev_segmaps[idx] = rev_seg_map.cuda()
-
-            idx = view2['idx'][v]
-            h, w = self.cogs[idx].shape[0], self.cogs[idx].shape[1]
-            cog_seg_map = cog_seg_maps[idx]
-            cog_seg_map = torch.from_numpy(cv2.resize(cog_seg_map, [w, h], interpolation=cv2.INTER_NEAREST))
-            rev_seg_map = rev_cog_seg_maps[idx]
-            rev_seg_map = torch.from_numpy(cv2.resize(rev_seg_map, [w, h], interpolation=cv2.INTER_NEAREST))
-
-            y, x = torch.meshgrid(torch.arange(0, h), torch.arange(0, w))
-            x = x.reshape(-1, 1)
-            y = y.reshape(-1, 1)
-            seg = cog_seg_map[y, x].squeeze(-1).long()
-
-            self.cogs[idx] = semantic_feats[seg].reshape(h, w, -1)
-            self.segmaps[idx] = cog_seg_map.cuda()
-            self.rev_segmaps[idx] = rev_seg_map.cuda()
+            self.segmaps[idx] = cog_seg_map.long().cuda()
+            self.rev_segmaps[idx] = rev_seg_map.long().cuda()
 
         self.rendered_imgs = []
 
     def render_image(self, text_feats, threshold=0.85):
         self.rendered_imgs = []
 
+        # Cosine similarity is constant within a segment, so score the feature table once
+        # and index it with the segmaps instead of scoring every pixel.
+        seg_similarity = cosine_similarity(self.semantic_feats, text_feats.to("cuda"), dim=-1)
+
         # Collect all cosine similarities to compute min-max normalization
         all_similarities = []
-        for each_cog in self.cogs:
-            similarity_map = cosine_similarity(each_cog.to("cpu"), text_feats.to("cpu").unsqueeze(1), dim=-1)
-            all_similarities.append(similarity_map.squeeze().numpy())
+        for segmap in self.segmaps:
+            all_similarities.append(seg_similarity[segmap].cpu().numpy())
 
         # Flatten and normalize all similarities
         total_similarities = np.concatenate(all_similarities)
@@ -187,7 +168,7 @@ class BasePCOptimizer (nn.Module):
         # normalized_similarities = [(sim - sim.min()) / (sim.max() - sim.min()) for sim in all_similarities]
 
         # Process each image with normalized similarities
-        for i, (each_cog, heatmap) in enumerate(zip(self.cogs, normalized_similarities)):
+        for i, heatmap in enumerate(normalized_similarities):
             mask = heatmap > threshold
 
             # Scale heatmap for visualization

--- a/modules/dust3r/cloud_opt/base_opt.py
+++ b/modules/dust3r/cloud_opt/base_opt.py
@@ -101,20 +101,26 @@ class BasePCOptimizer (nn.Module):
 
         # possibly store images for show_pointcloud
         self.imgs = None
-        if 'img' in view1 and 'img' in view2:
+        # inference() hands over a single deduplicated copy per image; fall back to the
+        # per-pair tensors when the output comes from somewhere that still carries them.
+        img_store = view1.get('img_store')
+        if img_store is None and 'img' in view1 and 'img' in view2:
+            img_store = {}
+            for v in range(len(self.edges)):
+                for view in (view1, view2):
+                    img_store.setdefault(view['idx'][v],
+                                         {k: view[k][v] for k in ('img', 'ori_img', 'smoothed_img')})
+
+        if img_store is not None:
             imgs = [torch.zeros((3,)+hw) for hw in self.imshapes]
             smoothed_imgs = [torch.zeros((3,)+hw) for hw in self.imshapes]
             ori_imgs = [torch.zeros((3,)+hw) for hw in self.imshapes]
-            for v in range(len(self.edges)):
-                idx = view1['idx'][v]
-                imgs[idx] = view1['img'][v]
-                smoothed_imgs[idx] = view1['smoothed_img'][v]
-                ori_imgs[idx] = view1['ori_img'][v]
-
-                idx = view2['idx'][v]
-                imgs[idx] = view2['img'][v]
-                smoothed_imgs[idx] = view2['smoothed_img'][v]
-                ori_imgs[idx] = view2['ori_img'][v]
+            for idx, view in img_store.items():
+                if idx >= len(imgs):
+                    continue
+                imgs[idx] = view['img']
+                smoothed_imgs[idx] = view['smoothed_img']
+                ori_imgs[idx] = view['ori_img']
 
             self.imgs = rgb(imgs)
             self.ori_imgs = rgb(ori_imgs)
@@ -443,7 +449,7 @@ class BasePCOptimizer (nn.Module):
         return refresh_confidence_map.view(H, W)
 
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def compute_global_alignment(self, tune_flg=False, init=None, niter_PnP=10, **kw):
         
         if tune_flg:

--- a/modules/dust3r/inference.py
+++ b/modules/dust3r/inference.py
@@ -52,8 +52,36 @@ def loss_of_one_batch(batch, model, criterion, device, symmetrize_batch=False, u
     return result[ret] if ret else result
 
 
+# The global aligner only reads pts3d/conf from the predictions, and it needs exactly one
+# copy of each image. With a 'complete' scene graph every image sits in N-1 pairs, so
+# keeping MASt3R's per-pixel descriptors and the per-pair image tensors costs ~37 of the
+# ~43 MB each pair otherwise occupies in host RAM. Drop them and keep the images once.
+UNUSED_PRED_KEYS = ('desc', 'desc_conf')
+IMG_KEYS = ('img', 'ori_img', 'smoothed_img')
+
+
+def dedup_images(pairs):
+    """One copy of each image, keyed by its index in the original image list."""
+    store = {}
+    for view in (view for pair in pairs for view in pair):
+        idx = int(view['idx'])
+        if idx not in store:
+            store[idx] = {k: view[k][0] for k in IMG_KEYS if k in view}
+    return store
+
+
+def drop_unused(res):
+    for view in (res['view1'], res['view2']):
+        for k in IMG_KEYS:
+            view.pop(k, None)
+    for pred in (res['pred1'], res['pred2']):
+        for k in UNUSED_PRED_KEYS:
+            pred.pop(k, None)
+    return res
+
+
 @torch.no_grad()
-def inference(pairs, model, device, batch_size=8, verbose=True):
+def inference(pairs, model, device, batch_size=8, verbose=True, use_amp=False):
     if verbose:
         print(f'>> Inference with model on {len(pairs)} image pairs')
     result = []
@@ -63,11 +91,15 @@ def inference(pairs, model, device, batch_size=8, verbose=True):
     if multiple_shapes:  # force bs=1
         batch_size = 1
 
+    img_store = dedup_images(pairs)
+
     for i in tqdm.trange(0, len(pairs), batch_size, disable=not verbose):
-        res = loss_of_one_batch(collate_with_cat(pairs[i:i + batch_size]), model, None, device)
-        result.append(to_cpu(res))
+        res = loss_of_one_batch(collate_with_cat(pairs[i:i + batch_size]), model, None, device,
+                                use_amp=use_amp)
+        result.append(to_cpu(drop_unused(res)))
 
     result = collate_with_cat(result, lists=multiple_shapes)
+    result['view1']['img_store'] = img_store
 
     return result
 

--- a/modules/pe3r/demo.py
+++ b/modules/pe3r/demo.py
@@ -593,9 +593,11 @@ def main_demo(tmpdirname, pe3r, device, server_name, server_port, silent=False):
                                                    ("swin: sliding window", "swin"),
                                                    ("oneref: match one image with all", "oneref")],
                                                   value='complete', label="Scenegraph",
-                                                  info="Define how to make pairs",
+                                                  info="Define how to make pairs. 'complete' is N*(N-1) pairs "
+                                                       "and its memory cost grows quadratically; switch to "
+                                                       "'swin' or 'oneref' for long sequences.",
                                                   interactive=True,
-                                                  visible=False)
+                                                  visible=True)
                 winsize = gradio.Slider(label="Scene Graph: Window Size", value=1,
                                         minimum=1, maximum=1, step=1, visible=False)
                 refid = gradio.Slider(label="Scene Graph: Id", value=0, minimum=0, maximum=0, step=1, visible=False)

--- a/modules/pe3r/demo.py
+++ b/modules/pe3r/demo.py
@@ -280,6 +280,12 @@ def get_mask_from_img_sam1(mobilesamv2, yolov8, sam1_image, yolov8_image, origin
 
     return ret_mask
 
+def pool_siglip_output(feats):
+    """SiglipModel.get_{image,text}_features returns the pooled tensor on
+    transformers 4.x, but the whole BaseModelOutputWithPooling on 5.x."""
+    return feats if torch.is_tensor(feats) else feats.pooler_output
+
+
 @torch.no_grad
 def get_cog_feats(images, pe3r):
     cog_seg_maps = []
@@ -384,7 +390,7 @@ def get_cog_feats(images, pe3r):
         inputs = pe3r.siglip_processor(images=seg_imgs, return_tensors="pt")
         inputs = {key: value.to("cuda") for key, value in inputs.items()}
         
-        image_features = pe3r.siglip.get_image_features(**inputs)
+        image_features = pool_siglip_output(pe3r.siglip.get_image_features(**inputs))
         image_features = image_features / image_features.norm(dim=-1, keepdim=True)
         image_features = image_features.detach().cpu()
 
@@ -518,7 +524,7 @@ def get_3D_object_from_scene(outdir, pe3r, silent, text, threshold, scene, min_c
     inputs = pe3r.siglip_tokenizer(text=texts, padding="max_length", return_tensors="pt")
     inputs = {key: value.to("cuda") for key, value in inputs.items()}
     with torch.no_grad():
-        text_feats =pe3r.siglip.get_text_features(**inputs)
+        text_feats = pool_siglip_output(pe3r.siglip.get_text_features(**inputs))
         text_feats = text_feats / text_feats.norm(dim=-1, keepdim=True)
     scene.render_image(text_feats, threshold)
     scene.ori_imgs = scene.rendered_imgs

--- a/modules/pe3r/demo.py
+++ b/modules/pe3r/demo.py
@@ -2,6 +2,7 @@ import math
 
 import gradio
 import os
+import traceback
 import torch
 import numpy as np
 import functools
@@ -471,6 +472,10 @@ def get_reconstructed_scene(outdir, pe3r, device, silent, filelist, schedule, ni
     # if mode == GlobalAlignerMode.PointCloudOptimizer:
     loss = scene_1.compute_global_alignment(tune_flg=True, init='mst', niter=niter, schedule=schedule, lr=lr)
 
+    # The second pass only overwrites imgs[i]['img'], so 'ori_img' -- and with it
+    # scene_1.ori_imgs -- still holds the unrendered images the fallback wants.
+    ori_imgs = scene_1.ori_imgs
+
     try:
         import torchvision.transforms as tvf
         ImgNorm = tvf.Compose([tvf.ToTensor(), tvf.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
@@ -481,15 +486,15 @@ def get_reconstructed_scene(outdir, pe3r, device, silent, filelist, schedule, ni
         output = inference(pairs, pe3r.mast3r, device, batch_size=1, verbose=not silent)
         mode = GlobalAlignerMode.PointCloudOptimizer if len(imgs) > 2 else GlobalAlignerMode.PairViewer
         scene = global_aligner(output, cog_seg_maps, rev_cog_seg_maps, cog_feats, device=device, mode=mode, verbose=not silent)
-        ori_imgs = scene.ori_imgs
         lr = 0.01
         # if mode == GlobalAlignerMode.PointCloudOptimizer:
         loss = scene.compute_global_alignment(tune_flg=False, init='mst', niter=niter, schedule=schedule, lr=lr)
-    except Exception as e:
+    except Exception:
         scene = scene_1
         scene.imgs = ori_imgs
         scene.ori_imgs = ori_imgs
-        print(e)
+        print('Second alignment pass failed, falling back to the first pass:')
+        traceback.print_exc()
 
 
     outfile = get_3D_model_from_scene(outdir, silent, scene, min_conf_thr, as_pointcloud, mask_sky,

--- a/modules/pe3r/demo.py
+++ b/modules/pe3r/demo.py
@@ -284,51 +284,58 @@ def get_mask_from_img_sam1(mobilesamv2, yolov8, sam1_image, yolov8_image, origin
 def get_cog_feats(images, pe3r):
     cog_seg_maps = []
     rev_cog_seg_maps = []
-    inference_state = pe3r.sam2.init_state(images=images.sam2_images, video_height=images.sam2_video_size[0], video_width=images.sam2_video_size[1])
+    # SAM 2's fused attention kernels only accept fp16/bf16; in fp32 they all bail out and
+    # scaled_dot_product_attention silently falls back to the slow math kernel. Run SAM 2
+    # under bf16 autocast and keep everything else (MobileSAM-v2, YOLOv8, SigLIP) in fp32.
+    with torch.autocast("cuda", dtype=torch.bfloat16):
+        inference_state = pe3r.sam2.init_state(images=images.sam2_images, video_height=images.sam2_video_size[0], video_width=images.sam2_video_size[1])
     mask_num = 0
 
     sam1_images = images.sam1_images
     sam1_images_size = images.sam1_images_size
     np_images = images.np_images
     np_images_size = images.np_images_size
-    
+
     sam1_masks = get_mask_from_img_sam1(pe3r.mobilesamv2, pe3r.yolov8, sam1_images[0], np_images[0], np_images_size[0], sam1_images_size[0], images.sam1_transform)
-    for mask in sam1_masks:
-        _, _, _ = pe3r.sam2.add_new_mask(
-            inference_state=inference_state,
-            frame_idx=0,
-            obj_id=mask_num,
-            mask=mask,
-        )
-        mask_num += 1
+    with torch.autocast("cuda", dtype=torch.bfloat16):
+        for mask in sam1_masks:
+            _, _, _ = pe3r.sam2.add_new_mask(
+                inference_state=inference_state,
+                frame_idx=0,
+                obj_id=mask_num,
+                mask=mask,
+            )
+            mask_num += 1
 
     video_segments = {}  # video_segments contains the per-frame segmentation results
-    for out_frame_idx, out_obj_ids, out_mask_logits in pe3r.sam2.propagate_in_video(inference_state):
-        sam2_masks = (out_mask_logits > 0.0).squeeze(1)
+    with torch.autocast("cuda", dtype=torch.bfloat16):
+        for out_frame_idx, out_obj_ids, out_mask_logits in pe3r.sam2.propagate_in_video(inference_state):
+            sam2_masks = (out_mask_logits > 0.0).squeeze(1)
 
-        video_segments[out_frame_idx] = {
-            out_obj_id: sam2_masks[i].cpu().numpy()
-            for i, out_obj_id in enumerate(out_obj_ids)
-        }
+            video_segments[out_frame_idx] = {
+                out_obj_id: sam2_masks[i].cpu().numpy()
+                for i, out_obj_id in enumerate(out_obj_ids)
+            }
 
-        if out_frame_idx == 0:
-            continue
+            if out_frame_idx == 0:
+                continue
 
-        sam1_masks = get_mask_from_img_sam1(pe3r.mobilesamv2, pe3r.yolov8, sam1_images[out_frame_idx], np_images[out_frame_idx], np_images_size[out_frame_idx], sam1_images_size[out_frame_idx], images.sam1_transform)
+            with torch.autocast("cuda", enabled=False):
+                sam1_masks = get_mask_from_img_sam1(pe3r.mobilesamv2, pe3r.yolov8, sam1_images[out_frame_idx], np_images[out_frame_idx], np_images_size[out_frame_idx], sam1_images_size[out_frame_idx], images.sam1_transform)
 
-        for sam1_mask in sam1_masks:
-            flg = 1
-            for sam2_mask in sam2_masks:
-                # print(sam1_mask.shape, sam2_mask.shape)
-                area1 = sam1_mask.sum()
-                area2 = sam2_mask.sum()
-                intersection = (sam1_mask & sam2_mask).sum()
-                if min(intersection / area1, intersection / area2) > 0.25:
-                    flg = 0
-                    break
-            if flg:
-                video_segments[out_frame_idx][mask_num] = sam1_mask.cpu().numpy()
-                mask_num += 1
+            for sam1_mask in sam1_masks:
+                flg = 1
+                for sam2_mask in sam2_masks:
+                    # print(sam1_mask.shape, sam2_mask.shape)
+                    area1 = sam1_mask.sum()
+                    area2 = sam2_mask.sum()
+                    intersection = (sam1_mask & sam2_mask).sum()
+                    if min(intersection / area1, intersection / area2) > 0.25:
+                        flg = 0
+                        break
+                if flg:
+                    video_segments[out_frame_idx][mask_num] = sam1_mask.cpu().numpy()
+                    mask_num += 1
 
     multi_view_clip_feats = torch.zeros((mask_num+1, 1024))
     multi_view_clip_feats_map = {}

--- a/modules/pe3r/demo.py
+++ b/modules/pe3r/demo.py
@@ -483,6 +483,10 @@ def get_reconstructed_scene(outdir, pe3r, device, silent, filelist, schedule, ni
             # print(imgs[i]['img'].shape, scene.imgs[i].shape, ImgNorm(scene.imgs[i])[None])
             imgs[i]['img'] = ImgNorm(scene_1.imgs[i])[None]
         pairs = make_pairs(imgs, scene_graph=scenegraph_type, prefilter=None, symmetrize=True)
+        # scene_1 already holds its own copy on the device, and the assignment below only
+        # rebinds after the new results exist -- so drop the first pass's predictions
+        # here to keep just one set of them in host memory.
+        del output
         output = inference(pairs, pe3r.mast3r, device, batch_size=1, verbose=not silent)
         mode = GlobalAlignerMode.PointCloudOptimizer if len(imgs) > 2 else GlobalAlignerMode.PairViewer
         scene = global_aligner(output, cog_seg_maps, rev_cog_seg_maps, cog_feats, device=device, mode=mode, verbose=not silent)

--- a/modules/ultralytics/nn/tasks.py
+++ b/modules/ultralytics/nn/tasks.py
@@ -515,7 +515,7 @@ def torch_safe_load(weight):
     check_suffix(file=weight, suffix='.pt')
     file = attempt_download_asset(weight)  # search online if missing locally
     try:
-        return torch.load(file, map_location='cpu'), file  # load
+        return torch.load(file, map_location='cuda', weights_only=False), file  # load
     except ModuleNotFoundError as e:  # e.name is missing module name
         if e.name == 'models':
             raise TypeError(

--- a/modules/ultralytics/yolo/utils/callbacks/dvc.py
+++ b/modules/ultralytics/yolo/utils/callbacks/dvc.py
@@ -1,7 +1,8 @@
 # Ultralytics YOLO 🚀, GPL-3.0 license
 import os
 
-import pkg_resources as pkg
+# 🌟 移除 pkg_resources，引入现代的版本解析库
+from packaging.version import parse as parse_version
 
 from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING
 from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
@@ -14,7 +15,8 @@ try:
     assert not TESTS_RUNNING  # do not log pytest
 
     ver = version('dvclive')
-    if pkg.parse_version(ver) < pkg.parse_version('2.11.0'):
+    # 🌟 使用 parse_version 替代 pkg.parse_version
+    if parse_version(ver) < parse_version('2.11.0'):
         LOGGER.debug(f'DVCLive is detected but version {ver} is incompatible (>=2.11 required).')
         dvclive = None  # noqa: F811
 except (ImportError, AssertionError, TypeError):

--- a/modules/ultralytics/yolo/utils/checks.py
+++ b/modules/ultralytics/yolo/utils/checks.py
@@ -13,11 +13,15 @@ from typing import Optional
 
 import cv2
 import numpy as np
-import pkg_resources as pkg
 import psutil
 import requests
 import torch
 from matplotlib import font_manager
+
+# 🌟 新增的现代依赖检查库，替代 pkg_resources
+import importlib.metadata
+from packaging.version import parse as parse_version, Version
+from packaging.requirements import Requirement
 
 from ultralytics.yolo.utils import (AUTOINSTALL, LOGGER, ONLINE, ROOT, USER_CONFIG_DIR, TryExcept, clean_url, colorstr,
                                     downloads, emojis, is_colab, is_docker, is_jupyter, is_kaggle, is_online,
@@ -27,16 +31,13 @@ from ultralytics.yolo.utils import (AUTOINSTALL, LOGGER, ONLINE, ROOT, USER_CONF
 def is_ascii(s) -> bool:
     """
     Check if a string is composed of only ASCII characters.
-
     Args:
         s (str): String to be checked.
-
     Returns:
         bool: True if the string is composed only of ASCII characters, False otherwise.
     """
     # Convert list, tuple, None, etc. to string
     s = str(s)
-
     # Check if the string is composed of only ASCII characters
     return all(ord(c) < 128 for c in s)
 
@@ -45,19 +46,9 @@ def check_imgsz(imgsz, stride=32, min_dim=1, max_dim=2, floor=0):
     """
     Verify image size is a multiple of the given stride in each dimension. If the image size is not a multiple of the
     stride, update it to the nearest multiple of the stride that is greater than or equal to the given floor value.
-
-    Args:
-        imgsz (int | cList[int]): Image size.
-        stride (int): Stride value.
-        min_dim (int): Minimum number of dimensions.
-        floor (int): Minimum allowed value for image size.
-
-    Returns:
-        (List[int]): Updated image size.
     """
     # Convert stride to integer if it is a tensor
     stride = int(stride.max() if isinstance(stride, torch.Tensor) else stride)
-
     # Convert image size to list if it is an integer
     if isinstance(imgsz, int):
         imgsz = [imgsz]
@@ -66,7 +57,6 @@ def check_imgsz(imgsz, stride=32, min_dim=1, max_dim=2, floor=0):
     else:
         raise TypeError(f"'imgsz={imgsz}' is of invalid type {type(imgsz).__name__}. "
                         f"Valid imgsz types are int i.e. 'imgsz=640' or list i.e. 'imgsz=[640,640]'")
-
     # Apply max_dim
     if len(imgsz) > max_dim:
         msg = "'train' and 'val' imgsz must be an integer, while 'predict' and 'export' imgsz may be a [h, w] list " \
@@ -77,14 +67,11 @@ def check_imgsz(imgsz, stride=32, min_dim=1, max_dim=2, floor=0):
         imgsz = [max(imgsz)]
     # Make image size a multiple of the stride
     sz = [max(math.ceil(x / stride) * stride, floor) for x in imgsz]
-
     # Print warning message if image size was updated
     if sz != imgsz:
         LOGGER.warning(f'WARNING ⚠️ imgsz={imgsz} must be multiple of max stride {stride}, updating to {sz}')
-
     # Add missing dimensions if necessary
     sz = [sz[0], sz[0]] if min_dim == 2 and len(sz) == 1 else sz[0] if min_dim == 1 and len(sz) == 1 else sz
-
     return sz
 
 
@@ -96,19 +83,9 @@ def check_version(current: str = '0.0.0',
                   verbose: bool = False) -> bool:
     """
     Check current version against the required minimum version.
-
-    Args:
-        current (str): Current version.
-        minimum (str): Required minimum version.
-        name (str): Name to be used in warning message.
-        pinned (bool): If True, versions must match exactly. If False, minimum version must be satisfied.
-        hard (bool): If True, raise an AssertionError if the minimum version is not met.
-        verbose (bool): If True, print warning message if minimum version is not met.
-
-    Returns:
-        (bool): True if minimum version is met, False otherwise.
     """
-    current, minimum = (pkg.parse_version(x) for x in (current, minimum))
+    # 🌟 使用 packaging.version.parse 替代 pkg.parse_version
+    current, minimum = (parse_version(x) for x in (current, minimum))
     result = (current == minimum) if pinned else (current >= minimum)  # bool
     warning_message = f'WARNING ⚠️ {name}{minimum} is required by YOLOv8, but {name}{current} is currently installed'
     if hard:
@@ -121,12 +98,6 @@ def check_version(current: str = '0.0.0',
 def check_latest_pypi_version(package_name='ultralytics'):
     """
     Returns the latest version of a PyPI package without downloading or installing it.
-
-    Parameters:
-        package_name (str): The name of the package to find the latest version for.
-
-    Returns:
-        (str): The latest version of the package.
     """
     with contextlib.suppress(Exception):
         requests.packages.urllib3.disable_warnings()  # Disable the InsecureRequestWarning
@@ -139,15 +110,13 @@ def check_latest_pypi_version(package_name='ultralytics'):
 def check_pip_update_available():
     """
     Checks if a new version of the ultralytics package is available on PyPI.
-
-    Returns:
-        (bool): True if an update is available, False otherwise.
     """
     if ONLINE and is_pip_package():
         with contextlib.suppress(Exception):
             from ultralytics import __version__
             latest = check_latest_pypi_version()
-            if pkg.parse_version(__version__) < pkg.parse_version(latest):  # update is available
+            # 🌟 使用 packaging.version.parse 替代 pkg.parse_version
+            if parse_version(__version__) < parse_version(latest):  # update is available
                 LOGGER.info(f'New https://pypi.org/project/ultralytics/{latest} available 😃 '
                             f"Update with 'pip install -U ultralytics'")
                 return True
@@ -157,25 +126,16 @@ def check_pip_update_available():
 def check_font(font='Arial.ttf'):
     """
     Find font locally or download to user's configuration directory if it does not already exist.
-
-    Args:
-        font (str): Path or name of font.
-
-    Returns:
-        file (Path): Resolved font file path.
     """
     name = Path(font).name
-
     # Check USER_CONFIG_DIR
     file = USER_CONFIG_DIR / name
     if file.exists():
         return file
-
     # Check system fonts
     matches = [s for s in font_manager.findSystemFonts() if font in s]
     if any(matches):
         return matches[0]
-
     # Download to USER_CONFIG_DIR if missing
     url = f'https://ultralytics.com/assets/{name}'
     if downloads.is_url(url):
@@ -186,12 +146,6 @@ def check_font(font='Arial.ttf'):
 def check_python(minimum: str = '3.7.0') -> bool:
     """
     Check current python version against the required minimum version.
-
-    Args:
-        minimum (str): Required minimum version of python.
-
-    Returns:
-        None
     """
     return check_version(platform.python_version(), minimum, name='Python ', hard=True)
 
@@ -200,13 +154,6 @@ def check_python(minimum: str = '3.7.0') -> bool:
 def check_requirements(requirements=ROOT.parent / 'requirements.txt', exclude=(), install=True, cmds=''):
     """
     Check if installed dependencies meet YOLOv8 requirements and attempt to auto-update if needed.
-
-    Args:
-        requirements (Union[Path, str, List[str]]): Path to a requirements.txt file, a single package requirement as a
-            string, or a list of package requirements as strings.
-        exclude (Tuple[str]): Tuple of package names to exclude from checking.
-        install (bool): If True, attempt to auto-update packages that don't meet requirements.
-        cmds (str): Additional commands to pass to the pip install command when auto-updating.
     """
     prefix = colorstr('red', 'bold', 'requirements:')
     check_python()  # check python version
@@ -215,19 +162,26 @@ def check_requirements(requirements=ROOT.parent / 'requirements.txt', exclude=()
         file = requirements.resolve()
         assert file.exists(), f'{prefix} {file} not found, check failed.'
         with file.open() as f:
-            requirements = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements(f) if x.name not in exclude]
+            # 🌟 使用 packaging.requirements.Requirement 替代 pkg.parse_requirements
+            parsed_reqs = [Requirement(line) for line in f if line.strip() and not line.strip().startswith('#')]
+            requirements = [str(x) for x in parsed_reqs if x.name not in exclude]
     elif isinstance(requirements, str):
         requirements = [requirements]
 
     s = ''  # console string
     n = 0  # number of packages updates
+
     for r in requirements:
+        req = Requirement(r)
         try:
-            pkg.require(r)
-        except (pkg.VersionConflict, pkg.DistributionNotFound):  # exception if requirements not met
+            # 🌟 使用 importlib.metadata 替代 pkg.require
+            installed_version = importlib.metadata.version(req.name)
+            if not req.specifier.contains(installed_version, prereleases=True):
+                raise importlib.metadata.PackageNotFoundError
+        except importlib.metadata.PackageNotFoundError:  # 🌟 替代 pkg.VersionConflict/DistributionNotFound
             try:  # attempt to import (slower but more accurate)
                 import importlib
-                importlib.import_module(next(pkg.parse_requirements(r)).name)
+                importlib.import_module(req.name)
             except ImportError:
                 s += f'"{r}" '
                 n += 1
@@ -246,7 +200,6 @@ def check_requirements(requirements=ROOT.parent / 'requirements.txt', exclude=()
                 return False
         else:
             return False
-
     return True
 
 
@@ -254,7 +207,7 @@ def check_suffix(file='yolov8n.pt', suffix='.pt', msg=''):
     """Check file(s) for acceptable suffix."""
     if file and suffix:
         if isinstance(suffix, str):
-            suffix = (suffix, )
+            suffix = (suffix,)
         for f in file if isinstance(file, (list, tuple)) else [file]:
             s = Path(f).suffix.lower().strip()  # file suffix
             if len(s):
@@ -324,13 +277,11 @@ def check_imshow(warn=False):
 def check_yolo(verbose=True, device=''):
     """Return a human-readable YOLO software and hardware summary."""
     from ultralytics.yolo.utils.torch_utils import select_device
-
     if is_jupyter():
         if check_requirements('wandb', install=False):
             os.system('pip uninstall -y wandb')  # uninstall wandb: unwanted account creation prompt with infinite hang
         if is_colab():
             shutil.rmtree('sample_data', ignore_errors=True)  # remove colab /sample_data directory
-
     if verbose:
         # System info
         gib = 1 << 30  # bytes per GiB
@@ -342,7 +293,6 @@ def check_yolo(verbose=True, device=''):
             display.clear_output()
     else:
         s = ''
-
     select_device(device=device, newline=False)
     LOGGER.info(f'Setup complete ✅ {s}')
 
@@ -350,17 +300,6 @@ def check_yolo(verbose=True, device=''):
 def check_amp(model):
     """
     This function checks the PyTorch Automatic Mixed Precision (AMP) functionality of a YOLOv8 model.
-    If the checks fail, it means there are anomalies with AMP on the system that may cause NaN losses or zero-mAP
-    results, so AMP will be disabled during training.
-
-    Args:
-        model (nn.Module): A YOLOv8 model instance.
-
-    Returns:
-        (bool): Returns True if the AMP functionality works correctly with YOLOv8 model, else False.
-
-    Raises:
-        AssertionError: If the AMP checks fail, indicating anomalies with the AMP functionality on the system.
     """
     device = next(model.parameters()).device  # get model device
     if device.type in ('cpu', 'mps'):


### PR DESCRIPTION
Nine independent fixes found while running the Gradio demo on a 100-image sequence.

## Summary

**1. Imports broken by newer dependency versions** — `models.curope` is not
importable from PE3R's layout so RoPE2D always fell back to the slow pytorch
path; `pkg_resources` was removed in setuptools 81; `torch.load` flipped
`weights_only` to True in torch 2.6. Also adds `modules/__init__.py` — without
it `modules/` is only a namespace-package portion, and any regular top-level
`modules` package in site-packages shadows it.

**2. SAM 2 ran in fp32** — its fused attention kernels only accept fp16/bf16, so
every backend bailed out and `scaled_dot_product_attention` fell through to the
math kernel, printing six warnings per run. Now wrapped in bf16 autocast, with
autocast explicitly disabled around MobileSAM-v2/YOLOv8 so their numerics are
untouched.

**3. `inference()` held 42.8 MB of host RAM per image pair** — 413 GB for 100
images with a `complete` scene graph. 63% of it was MASt3R's per-pixel
descriptors, which PE3R never reads, and 24% was image tensors duplicated into
all N-1 pairs an image appears in. Now 4.5 MB per pair, with bit-identical
reconstructed images.

**4. `AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'`
on transformers 5.x** — `SiglipModel.get_image_features` / `get_text_features`
returned the pooled tensor on 4.x but return the full model output on 5.x.
Unwrapped where needed so both major versions work.

**5. Undocumented checkpoints** — `models.py` loads `ObjectAwareModel.pt` and
`Prompt_guided_Mask_Decoder.pt` from `./checkpoints`, but the README never said
where to get them, so a fresh clone dies with a `FileNotFoundError`. Point at
the release that hosts them, note that the paths are relative to the working
directory, and fix the empty `git clone` URL and the missing `-r` on the pip
line while there.

**6. The optimizer materialised per-pixel semantic features** — one h*w*1024
fp32 tensor per image (0.56 GB at 288x512, so 56 GB for 100 images, allocated
twice), which was just `semantic_feats` gathered by the segmap. Both were
already stored, and its only reader scores each pixel against a text embedding
— constant within a segment. Score the table once and index it instead: the
per-image term drops from 578 MB to 3.3 MB, and similarity maps agree with the
old path to 1.5e-08.

**7. The alignment fallback masked the error that triggered it** — `ori_imgs`
was bound inside the `try`, after the second aligner was built, so an OOM
during `inference()` left it unbound and the `except` branch raised
`UnboundLocalError` instead of surfacing the real failure.

**8. The first pass's predictions outlived their use** — `output` is only
rebound once the second `inference()` returns, so both passes' results sat in
host memory at once.

**9. The scenegraph selector was built but hidden** — every run used
`complete`, whose N*(N-1) pair count is what makes long sequences fail. `swin`
and `oneref` were already implemented and wired; they just could not be
reached. Default unchanged.

## Testing

- Full `get_reconstructed_scene` + `get_3D_object_from_scene` run on a 5-image
  sequence; `.glb` output and text query both fine.
- `scene.imgs` / `ori_imgs` / `smoothed_imgs` verified equal to `load_images`
  output within 1e-6.
- `get_cog_feats` on 100 images: 15.65 GB peak GPU, flat in image count.
- `pool_siglip_output` checked against both the 4.x (`Tensor`) and 5.x
  (`BaseModelOutputWithPooling`) return shapes.
- All three scenegraph modes reconstruct and answer a text query on an 8-image
  sequence (56/32/14 pairs), with the pair memory dropping 1.57 GB -> 0.14/0.04 GB.
- The fallback path verified by forcing the second `inference()` to raise
  `OutOfMemoryError`: it now recovers and prints the originating traceback.

## Not included

`use_amp` is plumbed through `inference()` but defaults to off, so numerics are
unchanged. On an RTX 5090, fp16 autocast measured 1.49x faster with 0.03% median
depth error. `torch.compile` was 33% *slower* (78 graph breaks from curope's
pybind extension and a device sync in `dust3r/utils/misc.py:62`), so it is not
worth wiring up.